### PR TITLE
Fix problematic line in addFacet for coplanar facets

### DIFF
--- a/src/ConvexHull3D.h
+++ b/src/ConvexHull3D.h
@@ -155,7 +155,8 @@ sptr<HalfEdge> addNewFace(uint i_PtIdx, sptr<HalfEdge> i_HalfEdge)
     if (twin->m_Facet->isCoplanarWith(g_Pts[i_PtIdx])) {
         // Twin is now connected to the new point, which is connected to the 
         // end of the half-edge on horizon
-        twin->connectTo(g_Pts[i_PtIdx])->connectTo(twin->m_Next);
+		sptr<HalfEdge> temp(twin->m_Next);
+		twin->connectTo(g_Pts[i_PtIdx])->connectTo(temp);
         // Twin's twin is now unkown
         twin->m_Twin = NULL;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -95,21 +95,32 @@ inline void addCenteredVertex(sPoint i_Pt)
 
 void drawConvexHull()
 {
-    // For each facet
+	std::cout << "Drawing" << std::endl;
+	
+	// For each facet
     for (sptr<Facet>& facet : g_ConvexHull->m_Facets) {
         if (!facet) {
             continue;
         }
 
         // Draw each vertex
-        glBegin(g_Mode == FACETS ? GL_POLYGON : GL_LINES);
+        glBegin(g_Mode == FACETS ? GL_POLYGON : GL_LINE_LOOP);
 
         // Get normal
         Vector& normal(facet->m_Normal);
 
         sptr<HalfEdge> edge(facet->m_AnEdge);
         do {
-            addCenteredVertex(edge->m_Origin);
+			if (edge->m_Twin == edge->m_Next || edge->m_Twin == edge->m_Prev)
+			{
+				glColor3f(1, 0, 0);
+			}
+			else
+			{
+				glColor3f(1, 1, 1);
+			}
+			
+			addCenteredVertex(edge->m_Origin);
             glNormal3d(normal.m_x, normal.m_y, normal.m_z);
             edge = edge->m_Next;
         } while (edge != facet->m_AnEdge);


### PR DESCRIPTION
Fix problematic line in addFacet for coplanar facets; Add red color when twin==next or twin==prev
